### PR TITLE
FLO-26389 - Support removal of foreign keys

### DIFF
--- a/src/nodetree_tree_sql.erl
+++ b/src/nodetree_tree_sql.erl
@@ -283,10 +283,18 @@ create_node(Host, Node, Type, Owner, Options, Parents) ->
 delete_node(Host, Node) ->
     lists:map(
 	fun(Rec) ->
-	    Nidx = Rec#pubsub_node.id,
-	    catch ejabberd_sql:sql_query_t(
-		    ?SQL("delete from pubsub_node where nodeid=%(Nidx)d")),
-	    Rec
+		Nidx = Rec#pubsub_node.id,
+		catch ejabberd_sql:sql_query_t(
+			?SQL("delete from pubsub_node where nodeid=%(Nidx)d;")),
+		catch ejabberd_sql:sql_query_t(
+			?SQL("delete from pubsub_node_option where nodeid=%(Nidx)d;")),
+		catch ejabberd_sql:sql_query_t(
+			?SQL("delete from pubsub_node_owner where nodeid=%(Nidx)d;")),
+		catch ejabberd_sql:sql_query_t(
+			?SQL("delete from pubsub_state where nodeid=%(Nidx)d;")),
+		catch ejabberd_sql:sql_query_t(
+			?SQL("delete from pubsub_item where nodeid=%(Nidx)d;")),
+		Rec
 	end, get_subnodes_tree(Host, Node)).
 
 %% helpers


### PR DESCRIPTION
As part of the migration to TiDB, we will be removing foreign keys from the chat database, meaning we can no longer rely on ON DELETE CASCADE behavior. This code change explicitly deletes the relevant related records after we remove an individual pubsub_node.
